### PR TITLE
Added CopySubset command

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,7 +49,7 @@
   <PropertyGroup>
     <Product>dotnet-subset</Product>
     <Description>.NET Tool to copy a subset of files from a repository to a directory</Description>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <Company>Nimbleways</Company>
     <Authors>$(Company.ToLower())</Authors>
     <Copyright>© $(Company). All rights reserved.</Copyright>

--- a/README.md
+++ b/README.md
@@ -29,10 +29,15 @@ Prerequisite: .NET SDK 6
 Description:
   Create a subset for the restore operation.
 
+Commands
+  - `restore`: creates a subset of project files and related nuget configs only
+  - `copy`: creates a subset of all files from related projects and related imports 
+
 Usage:
-  dotnet-subset restore <projectOrSolution> [options]
+  dotnet-subset <command> <projectOrSolution> [options]
 
 Arguments:
+  <command>            `restore` or `copy`
   <projectOrSolution>  Project or solution to restore.
 
 Options:

--- a/src/dotnet-subset/Commands/CopySubset.cs
+++ b/src/dotnet-subset/Commands/CopySubset.cs
@@ -1,0 +1,44 @@
+using Microsoft.Build.Evaluation;
+
+namespace Nimbleways.Tools.Subset.Commands;
+
+internal class CopySubset : SubsetCommandBase
+{
+    protected override IEnumerable<string> GetFilesToCopy(string projectOrSolution, string rootFolder)
+    {
+        using ProjectCollection projectCollection = new();
+        Dictionary<string, Project> projectsByFullPath = new();
+        foreach (string? project in GetRootProjects(projectOrSolution))
+        {
+            VisitAllProjects(projectCollection, rootFolder, project, projectsByFullPath);
+        }
+
+        string projectListAsString = string.Join(Environment.NewLine + " - ", projectsByFullPath.Keys.OrderBy(f => f));
+        Console.WriteLine($"Found {projectsByFullPath.Count} project(s) to copy:{Environment.NewLine + " - "}{projectListAsString}");
+
+        var projectFiles = GetProjectFiles(projectsByFullPath);
+
+        List<string> extraFilesInvolvedInRestore = projectsByFullPath.Values
+            .SelectMany(project => GetExtraFilesInvolvedInRestore(rootFolder, project))
+            .Distinct()
+            .ToList();
+        if (IsSolutionFile(projectOrSolution))
+        {
+            extraFilesInvolvedInRestore.Add(projectOrSolution);
+        }
+
+        if (extraFilesInvolvedInRestore.Count > 0)
+        {
+            string extraFilesInvolvedInRestoreAsString = string.Join(Environment.NewLine + " - ", extraFilesInvolvedInRestore.OrderBy(f => f));
+            Console.WriteLine($"Found {extraFilesInvolvedInRestore.Count} extra file(s) to copy:{Environment.NewLine + " - "}{extraFilesInvolvedInRestoreAsString}");
+        }
+
+        IEnumerable<string> allFilesToCopy = projectsByFullPath.Keys.Concat(extraFilesInvolvedInRestore).Distinct();
+        return allFilesToCopy;
+    }
+
+    private static IEnumerable<string> GetProjectFiles(Dictionary<string, Project> projects)
+    {
+        return projects.Values.SelectMany(project => Directory.EnumerateFiles(project.DirectoryPath, "*.*", SearchOption.AllDirectories));
+    }
+}

--- a/src/dotnet-subset/Commands/RestoreSubset.cs
+++ b/src/dotnet-subset/Commands/RestoreSubset.cs
@@ -1,0 +1,39 @@
+using Microsoft.Build.Evaluation;
+
+namespace Nimbleways.Tools.Subset.Commands;
+
+internal class RestoreSubset : SubsetCommandBase
+{
+
+    protected override IEnumerable<string> GetFilesToCopy(string projectOrSolution, string rootFolder)
+    {
+        using ProjectCollection projectCollection = new();
+        Dictionary<string, Project> projectsByFullPath = new();
+        foreach (string? project in GetRootProjects(projectOrSolution))
+        {
+            VisitAllProjects(projectCollection, rootFolder, project, projectsByFullPath);
+        }
+
+        string projectListAsString = string.Join(Environment.NewLine + " - ", projectsByFullPath.Keys.OrderBy(f => f));
+        Console.WriteLine($"Found {projectsByFullPath.Count} project(s) to copy:{Environment.NewLine + " - "}{projectListAsString}");
+        IEnumerable<string> nugetConfigFiles = GetNugetConfigFiles(rootFolder, projectsByFullPath);
+        List<string> extraFilesInvolvedInRestore = projectsByFullPath.Values
+            .SelectMany(project => GetExtraFilesInvolvedInRestore(rootFolder, project))
+            .Concat(nugetConfigFiles)
+            .Distinct()
+            .ToList();
+        if (IsSolutionFile(projectOrSolution))
+        {
+            extraFilesInvolvedInRestore.Add(projectOrSolution);
+        }
+
+        if (extraFilesInvolvedInRestore.Count > 0)
+        {
+            string extraFilesInvolvedInRestoreAsString = string.Join(Environment.NewLine + " - ", extraFilesInvolvedInRestore.OrderBy(f => f));
+            Console.WriteLine($"Found {extraFilesInvolvedInRestore.Count} extra file(s) to copy:{Environment.NewLine + " - "}{extraFilesInvolvedInRestoreAsString}");
+        }
+
+        IEnumerable<string> allFilesToCopy = projectsByFullPath.Keys.Concat(extraFilesInvolvedInRestore).Distinct();
+        return allFilesToCopy;
+    }
+}

--- a/src/dotnet-subset/Program.cs
+++ b/src/dotnet-subset/Program.cs
@@ -5,7 +5,7 @@ using System.CommandLine;
 
 using Microsoft.Build.Locator;
 
-using Nimbleways.Tools.Subset;
+using Nimbleways.Tools.Subset.Commands;
 
 MSBuildLocator.RegisterDefaults();
 
@@ -25,15 +25,26 @@ var outputDirectoryOption = new Option<DirectoryInfo>(
 
 var rootCommand = new RootCommand(".NET Tool to copy a subset of files from a repository to a directory.");
 
-var readCommand = new Command("restore", "Create a subset for the restore operation.")
+var restoreCommand = new Command("restore", "Create a subset for the restore operation.")
             {
                 rootDirectoryOption,
                 outputDirectoryOption,
             };
-readCommand.AddArgument(projectOrSolutionArgument);
-rootCommand.AddCommand(readCommand);
+restoreCommand.AddArgument(projectOrSolutionArgument);
+rootCommand.AddCommand(restoreCommand);
 
-readCommand.SetHandler((projectOrSolution, rootDirectory, outputDirectory) => RestoreSubset.Execute(projectOrSolution.FullName, rootDirectory.FullName, outputDirectory.FullName),
+restoreCommand.SetHandler((projectOrSolution, rootDirectory, outputDirectory) => new RestoreSubset().Execute(projectOrSolution.FullName, rootDirectory.FullName, outputDirectory.FullName),
+    projectOrSolutionArgument, rootDirectoryOption, outputDirectoryOption);
+
+var copyCommand = new Command("copy", "Create subset of files, including all files of relevant projects")
+{
+    rootDirectoryOption,
+    outputDirectoryOption,
+};
+copyCommand.AddArgument(projectOrSolutionArgument);
+rootCommand.AddCommand(copyCommand);
+
+copyCommand.SetHandler((projectOrSolution, rootDirectory, outputDirectory) => new CopySubset().Execute(projectOrSolution.FullName, rootDirectory.FullName, outputDirectory.FullName),
     projectOrSolutionArgument, rootDirectoryOption, outputDirectoryOption);
 
 return rootCommand.Invoke(args);


### PR DESCRIPTION
Added a copy subset for use in our company. 
This is super useful for our docker files that rely on a large context but don't want to lose the caching when nothing relevant has changed. We use multibuild stages to help with this

```Dockerfile
FROM mcr.microsoft.com/dotnet/sdk:6.0 as src
WORKDIR /src
COPY custom-packages custom-packages
RUN dotnet tool install dotnet-subset --global --no-cache --version 0.4.0 --add-source custom-packages
COPY . . 
RUN dotnet subset copy /src/ProjectA/ProjectA.csproj --root-directory /src --output /outgoing

# If the none of the ProjectA or related project files have changed, then all the following will use the cached layers
FROM mcr.microsoft.com/dotnet/sdk:6.0 as src as build
WORKDIR /src
COPY --from=src /outgoing/ .
RUN dotnet restore
RUN dotnet build --no-restore

```   