### PR TITLE
Handle running in root directory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,7 +49,7 @@
   <PropertyGroup>
     <Product>dotnet-subset</Product>
     <Description>.NET Tool to copy a subset of files from a repository to a directory</Description>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <Company>Nimbleways</Company>
     <Authors>$(Company.ToLower())</Authors>
     <Copyright>© $(Company). All rights reserved.</Copyright>

--- a/src/dotnet-subset/RestoreSubset.cs
+++ b/src/dotnet-subset/RestoreSubset.cs
@@ -156,9 +156,9 @@ internal static class RestoreSubset
     }
     private static IEnumerable<string> GetNugetConfigFiles(string rootFolder, Dictionary<string, Project> projects)
     {
-        static void GetNugetConfigFiles(string rootFolder, DirectoryInfo folder, IDictionary<string, string> nugetConfigFiles)
+        static void GetNugetConfigFiles(string rootFolder, DirectoryInfo? folder, IDictionary<string, string> nugetConfigFiles)
         {
-            if (nugetConfigFiles.ContainsKey(folder.FullName) || !IsSameOrUnder(rootFolder, folder.FullName))
+            if (folder == null || nugetConfigFiles.ContainsKey(folder.FullName) || !IsSameOrUnder(rootFolder, folder.FullName))
             {
                 return;
             }
@@ -171,7 +171,7 @@ internal static class RestoreSubset
                 nugetConfigFiles.Add(folder.FullName, f);
             }
 
-            GetNugetConfigFiles(rootFolder, folder.Parent!, nugetConfigFiles);
+            GetNugetConfigFiles(rootFolder, folder.Parent, nugetConfigFiles);
         }
         var nugetConfigFilesByFolder = new Dictionary<string, string>();
         var csprojDefinedNugetConfigFiles = new List<string>();
@@ -198,7 +198,7 @@ internal static class RestoreSubset
             }
             else
             {
-                GetNugetConfigFiles(rootFolder, Directory.GetParent(projectPath)!, nugetConfigFilesByFolder);
+                GetNugetConfigFiles(rootFolder, Directory.GetParent(projectPath), nugetConfigFilesByFolder);
             }
         }
         return nugetConfigFilesByFolder.Values.Concat(csprojDefinedNugetConfigFiles);


### PR DESCRIPTION
Running `dotnet subset` in the root directory throws an exception:
```
#12 1.910 Unhandled exception: System.NullReferenceException: Object reference not set to an instance of an object.
#12 1.914    at Nimbleways.Tools.Subset.RestoreSubset.<GetNugetConfigFiles>g__GetNugetConfigFiles|8_0(String rootFolder, DirectoryInfo folder, IDictionary`2 nugetConfigFiles) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/RestoreSubset.cs:line 161
#12 1.914    at Nimbleways.Tools.Subset.RestoreSubset.<GetNugetConfigFiles>g__GetNugetConfigFiles|8_0(String rootFolder, DirectoryInfo folder, IDictionary`2 nugetConfigFiles) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/RestoreSubset.cs:line 174
#12 1.915    at Nimbleways.Tools.Subset.RestoreSubset.<GetNugetConfigFiles>g__GetNugetConfigFiles|8_0(String rootFolder, DirectoryInfo folder, IDictionary`2 nugetConfigFiles) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/RestoreSubset.cs:line 174
#12 1.917    at Nimbleways.Tools.Subset.RestoreSubset.<GetNugetConfigFiles>g__GetNugetConfigFiles|8_0(String rootFolder, DirectoryInfo folder, IDictionary`2 nugetConfigFiles) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/RestoreSubset.cs:line 174
#12 1.917    at Nimbleways.Tools.Subset.RestoreSubset.GetNugetConfigFiles(String rootFolder, Dictionary`2 projects) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/RestoreSubset.cs:line 204
#12 1.917    at Nimbleways.Tools.Subset.RestoreSubset.Execute(String projectOrSolution, String rootFolder, String destinationFolder) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/RestoreSubset.cs:line 23
#12 1.917    at Program.<>c.<<Main>$>b__0_0(FileInfo projectOrSolution, DirectoryInfo rootDirectory, DirectoryInfo outputDirectory) in /home/runner/work/dotnet-subset/dotnet-subset/src/dotnet-subset/Program.cs:line 36
```